### PR TITLE
Fix link to Learning Python resources.

### DIFF
--- a/Index.ipynb
+++ b/Index.ipynb
@@ -86,7 +86,7 @@
     "## [Examples](examples/examples.ipynb)\n",
     "    Example notebooks demonstrating some of the installed packages\n",
     "\n",
-    "## [Learning Python](python/Index.ipynb) \n",
+    "## [Learning Python](examples/python/LearningPython.ipynb) \n",
     "    Materials for learning Python, focusing on scientific programing.\n",
     "\n",
     "## [Presentations](presentations/presentations.ipynb)\n",


### PR DESCRIPTION
In the Examples, the supplied link to Learning Python was throwing a 404--path was incorrect.

This pull request fixes the link.